### PR TITLE
Podcast coverart is now included as property into Episode

### DIFF
--- a/common/GPodderPlayback.qml
+++ b/common/GPodderPlayback.qml
@@ -28,6 +28,7 @@ MediaPlayer {
     property string episode_title: ''
     property var episode_chapters: ([])
     property string podcast_title: ''
+    property string podcast_coverart: ''
     signal playerCreated()
 
     property var queue: ([])
@@ -109,6 +110,7 @@ MediaPlayer {
             player.episode_title = episode.title;
             player.episode_chapters = episode.chapters;
             player.podcast_title = episode.podcast_title;
+            player.podcast_coverart = episode.podcast_coverart;
             var source = episode.source;
             if (source.indexOf('/') === 0) {
                 player.source = 'file://' + source;

--- a/main.py
+++ b/main.py
@@ -356,6 +356,7 @@ class gPotherSide:
         return {
             'title': episode.title,
             'podcast_title': episode.podcast.title,
+            'podcast_coverart': self._get_cover(episode.podcast),
             'source': episode.local_filename(False) if episode.state == gpodder.STATE_DOWNLOADED else episode.url,
             'position': episode.current_position,
             'total': episode.total_time,


### PR DESCRIPTION
Having access to the cover art for each Episode, and not only Podcast, is useful for showing it:

- In the Now playing view
- In Filtered lists with episodes from different podcasts
